### PR TITLE
Add syntax highlighting code block plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
 		"node_modules/**",
 		"vendor/**",
 		"mu-plugins/query-monitor/**",
+		"mu-plugins/syntax-highlighting-code-block/**",
 		"mu-plugins/wordpress-seo/**",
 		"mu-plugins/wp-user-profiles/**"
 	]

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ themes/twenty*
 
 # Mu-plugins via Composer
 mu-plugins/query-monitor
+mu-plugins/syntax-highlighting-code-block
 mu-plugins/wp-user-profiles
 mu-plugins/wordpress-seo

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,6 +11,7 @@
 		"node_modules/**",
 		"vendor/**",
 		"mu-plugins/query-monitor/**",
+		"mu-plugins/syntax-highlighting-code-block/**",
 		"mu-plugins/wordpress-seo/**",
 		"mu-plugins/wp-user-profiles/**"
 	]

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 			"mu-plugins/{$name}/": [
 				"type:wordpress-muplugin",
 				"wpackagist-plugin/query-monitor",
+				"wpackagist-plugin/syntax-highlighting-code-block",
 				"wpackagist-plugin/wp-user-profiles",
 				"yoast/wordpress-seo"
 			], 
@@ -43,7 +44,8 @@
 	"require": {
 		"wpackagist-plugin/query-monitor": "^3.10",
 		"wpackagist-plugin/wp-user-profiles": "^2.6",
-		"yoast/wordpress-seo": "^20.0"
+		"yoast/wordpress-seo": "^20.0",
+		"wpackagist-plugin/syntax-highlighting-code-block": "^1.3"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98200c634ac3a119e7ea75dd98bf60b3",
+    "content-hash": "68edb18645309ff1b53db44f72b65d21",
     "packages": [
         {
             "name": "composer/installers",
@@ -168,6 +168,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/query-monitor/"
+        },
+        {
+            "name": "wpackagist-plugin/syntax-highlighting-code-block",
+            "version": "1.3.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/syntax-highlighting-code-block/",
+                "reference": "tags/1.3.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/syntax-highlighting-code-block.1.3.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/syntax-highlighting-code-block/"
         },
         {
             "name": "wpackagist-plugin/wp-user-profiles",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,7 @@
 
 	<!-- Exclude third party plugins -->
 	<exclude-pattern>./mu-plugins/query-monitor/*</exclude-pattern>
+	<exclude-pattern>./mu-plugins/syntax-highlighting-code-block/*</exclude-pattern>
 	<exclude-pattern>./mu-plugins/wordpress-seo/*</exclude-pattern>
 	<exclude-pattern>./mu-plugins/wp-user-profiles/*</exclude-pattern>
 


### PR DESCRIPTION
 Specifically chose this plugin because it uses server-side rendered block with support for AMP.